### PR TITLE
fix: type with zero ydotool inter-key delay to avoid dropped spaces

### DIFF
--- a/daemon/push_to_talk.py
+++ b/daemon/push_to_talk.py
@@ -107,12 +107,15 @@ class BaseRecorder:
         if self.display_server == "wayland" or (
             self.display_server == "auto" and os.environ.get("WAYLAND_DISPLAY")
         ):
-            # Use ydotool which creates a real uinput device — no space dropping
-            cmd = ["ydotool", "type", "-d", "2", "-H", "0", "--", text]
+            # Type at full speed: TUI apps (e.g. Claude Code) drop
+            # individual rapid space keypresses, but a zero-delay burst
+            # coalesces at the pty into paste-like chunks that survive
+            # intact. Any inter-key delay makes the dropping worse.
+            cmd = ["ydotool", "type", "-d", "0", "-H", "0", "--", text]
         elif self.display_server == "x11":
             cmd = ["xdotool", "type", "--clearmodifiers", "--", text]
         else:
-            cmd = ["ydotool", "type", "-d", "2", "-H", "0", "--", text]
+            cmd = ["ydotool", "type", "-d", "0", "-H", "0", "--", text]
 
         proc = await asyncio.create_subprocess_exec(
             *cmd,


### PR DESCRIPTION
Closes #17.

## Problem

Dictated text arriving in locally-running TUI apps (Claude Code in ghostty) loses most of its spaces, while the same dictation into an SSH session arrives intact.

## Investigation

Ruled out, with measurements on sesimbra:

- **whisper / HTTP transfer** — the daemon log shows the transcription with all spaces present.
- **keyd** — although keyd grabs the ydotoold virtual device (`ids = ["*"]`), capturing events on keyd's virtual output keyboard showed all 19 space down/up events of a test string pass through.
- **compositor (COSMIC)** — see timing table below: slower typing loses *more* spaces, the opposite of an event-timing race.

Typing the same 19-space test string into the Claude Code input box with different `ydotool type` flags:

| flags | spaces surviving |
|---|---|
| `-d 0 -H 0` | **all 19** |
| `-d 2 -H 0` (previous default) | partial, degrading over the string |
| `-d 8 -H 4` | 1 |
| `-d 20 -H 10` | 1 |
| ydotool defaults | 1 |

## Root cause

TUI apps drop individual rapid space keypresses delivered one keystroke at a time. A zero-delay burst coalesces at the pty into paste-like chunks, which are handled through the bulk-input path and survive intact. This also explains the SSH mystery: the network batches keystroke bytes into packets, so the remote side always receives chunks. The 2 ms inter-key delay introduced in 848bf7b as a mitigation actually made the problem worse.

## Change

`ydotool type -d 2 -H 0` → `ydotool type -d 0 -H 0` in both wayland and fallback branches of `_type_text`, with a comment documenting why full speed is load-bearing.

The x11/xdotool branch is untouched. The `push-to-talk-exit-on-lost-device.patch` carried in the infrastructure repo still applies.

## Testing

- `just ci` (nix build + 18 pytest tests) passes.
- Live-verified on sesimbra: `-d 0 -H 0` delivered the full test string with all spaces into the previously-failing Claude Code window.